### PR TITLE
Dispatch instead of separate functions for module create

### DIFF
--- a/src/intertypes/InterTypes.jl
+++ b/src/intertypes/InterTypes.jl
@@ -1,5 +1,5 @@
 module InterTypes
-export InterType, InterTypeDecl, Binary, generate_module, intertype, @intertypes
+export InterType, InterTypeDecl, Binary, LanguageTarget, SerializationTarget, generate_module, intertype, @intertypes
 
 using MLStyle
 using OrderedCollections
@@ -100,10 +100,17 @@ end
 
 function intertype end
 
-struct ExportTarget{type} end
+abstract type ExportTarget end
+abstract type LanguageTarget <: ExportTarget end
+abstract type SerializationTarget <: ExportTarget end
 
-function generate_module(mod::Module, export_type::Symbol=:json, path="."; target_specific_args...)
-  generate_module(mod.Meta, ExportTarget{export_type}, path; target_specific_args...)
+"""
+    generate_module(mod::Module, target::Type{<:ExportTarget}, path="."; target_specific_args...)
+  
+Generate files that define the intertypes for the specified target. 
+"""
+function generate_module(mod::Module, target::Type{<:ExportTarget}, path="."; target_specific_args...)
+  generate_module(mod.Meta, target, path; target_specific_args...)
 end
 
 include("json.jl")

--- a/src/intertypes/InterTypes.jl
+++ b/src/intertypes/InterTypes.jl
@@ -1,5 +1,5 @@
 module InterTypes
-export InterType, InterTypeDecl, Binary, intertype, @intertypes
+export InterType, InterTypeDecl, Binary, generate_module, intertype, @intertypes
 
 using MLStyle
 using OrderedCollections
@@ -99,6 +99,12 @@ struct InterTypeModule
 end
 
 function intertype end
+
+struct ExportTarget{type} end
+
+function generate_module(mod::Module, export_type::Symbol=:json, path="."; target_specific_args...)
+  generate_module(mod.Meta, ExportTarget{export_type}, path; target_specific_args...)
+end
 
 include("json.jl")
 include("sexp.jl")

--- a/src/intertypes/json.jl
+++ b/src/intertypes/json.jl
@@ -1,4 +1,4 @@
-export tojsonschema, jsonwrite, jsonread
+export JSONTarget, tojsonschema, jsonwrite, jsonread
 
 using OrderedCollections
 using Base64
@@ -358,8 +358,16 @@ function acsettype(spec)
   )
 end
 
+"""
+    JSONTarget  
+
+Specifies a serialization target of JSON Schema when
+generating a module.
+"""
+struct JSONTarget <: SerializationTarget end
+
 function generate_module(
-  mod::InterTypeModule, ::Type{ExportTarget{:json}}, path
+  mod::InterTypeModule, ::Type{JSONTarget}, path
   ;ac=JSON3.AlignmentContext(indent=2)
 )
   defs = Pair{String, Object}[]

--- a/src/intertypes/json.jl
+++ b/src/intertypes/json.jl
@@ -1,4 +1,4 @@
-export tojsonschema, jsonwrite, jsonread, generate_jsonschema_module
+export tojsonschema, jsonwrite, jsonread
 
 using OrderedCollections
 using Base64
@@ -358,8 +358,8 @@ function acsettype(spec)
   )
 end
 
-function generate_jsonschema_module(
-  mod::InterTypeModule, path="."
+function generate_module(
+  mod::InterTypeModule, ::Type{ExportTarget{:json}}, path
   ;ac=JSON3.AlignmentContext(indent=2)
 )
   defs = Pair{String, Object}[]
@@ -388,8 +388,4 @@ function generate_jsonschema_module(
   open(schema_filepath, "w") do io
     JSON3.pretty(io, schema, ac)
   end
-end
-
-function generate_jsonschema_module(mod::Module, path=".")
-  generate_jsonschema_module(mod.Meta, path)
 end

--- a/src/intertypes/python.jl
+++ b/src/intertypes/python.jl
@@ -1,3 +1,5 @@
+export PydanticTarget
+
 function topy(intertype::InterType; forward_ref=true)
   @match intertype begin
     I32 => "int"
@@ -139,6 +141,7 @@ from intertypes import SafeInt, InterTypeBase
 from acsets import Ob, Hom, Attr, AttrType, Schema, ACSet
 """
 
+# TODO: Expose this to the user? Write automatically for the user?
 INTERTYPE_PYTHON_MODULE = """
 from typing import Annotated
 
@@ -154,7 +157,18 @@ class InterTypeBase(BaseModel):
         return super().model_dump_json(*args, **kwargs, by_alias=True)
 """
 
-function generate_module(mod::InterTypeModule, ::Type{ExportTarget{:python}}, path)
+
+"""
+    PydanticTarget  
+
+Targets the creation of `.py` files that use the Pydantic library
+which enables integration with the Python language (specifically
+when (de)serializing JSON).
+"""
+struct PydanticTarget <: LanguageTarget end
+
+
+function generate_module(mod::InterTypeModule, ::Type{PydanticTarget}, path)
   outfile = joinpath(path, string(mod.name) * ".py")
   open(outfile, "w") do io
     print(io, PYTHON_PREAMBLE)

--- a/src/intertypes/python.jl
+++ b/src/intertypes/python.jl
@@ -1,5 +1,3 @@
-export generate_python_module
-
 function topy(intertype::InterType; forward_ref=true)
   @match intertype begin
     I32 => "int"
@@ -156,7 +154,7 @@ class InterTypeBase(BaseModel):
         return super().model_dump_json(*args, **kwargs, by_alias=True)
 """
 
-function generate_python_module(mod::InterTypeModule, path)
+function generate_module(mod::InterTypeModule, ::Type{ExportTarget{:python}}, path)
   outfile = joinpath(path, string(mod.name) * ".py")
   open(outfile, "w") do io
     print(io, PYTHON_PREAMBLE)
@@ -172,9 +170,4 @@ function generate_python_module(mod::InterTypeModule, path)
       topy(io, name, decl)
     end
   end
-end
-
-
-function generate_python_module(mod::Module, path=".")
-  generate_python_module(mod.Meta, path)
 end

--- a/test/intertypes/InterTypes.jl
+++ b/test/intertypes/InterTypes.jl
@@ -43,7 +43,7 @@ s = jsonwrite(t)
 
 @test jsonread(s, Term) == t
 
-generate_module(simpleast)
+generate_module(simpleast, JSONTarget)
 
 simpleast_schema = JSONSchema.Schema(read("simpleast_schema.json", String))
 
@@ -71,7 +71,7 @@ add_part!(g, :E, src=1, tgt=2, weight=EdgeData(:mass_ave, 42))
 
 @test testjson(m)
 
-generate_module(wgraph)
+generate_module(wgraph, JSONTarget)
 
 wgraph_schema = JSONSchema.Schema(read("wgraph_schema.json", String))
 
@@ -86,9 +86,9 @@ wgraph_schema = JSONSchema.Schema(read("wgraph_schema.json", String))
 
   dir = @__DIR__
   write(dir * "/intertypes.py", InterTypes.INTERTYPE_PYTHON_MODULE)
-  generate_module(simpleast, :python, dir)
-  generate_module(model, :python, dir)
-  generate_module(wgraph, :python, dir)
+  generate_module(simpleast, PydanticTarget, dir)
+  generate_module(model, PydanticTarget, dir)
+  generate_module(wgraph, PydanticTarget, dir)
 
   pushfirst!(PyList(pyimport("sys")."path"), Py(dir))
 

--- a/test/intertypes/InterTypes.jl
+++ b/test/intertypes/InterTypes.jl
@@ -43,7 +43,7 @@ s = jsonwrite(t)
 
 @test jsonread(s, Term) == t
 
-generate_jsonschema_module(simpleast, ".")
+generate_module(simpleast)
 
 simpleast_schema = JSONSchema.Schema(read("simpleast_schema.json", String))
 
@@ -71,7 +71,7 @@ add_part!(g, :E, src=1, tgt=2, weight=EdgeData(:mass_ave, 42))
 
 @test testjson(m)
 
-generate_jsonschema_module(wgraph, ".")
+generate_module(wgraph)
 
 wgraph_schema = JSONSchema.Schema(read("wgraph_schema.json", String))
 
@@ -86,9 +86,9 @@ wgraph_schema = JSONSchema.Schema(read("wgraph_schema.json", String))
 
   dir = @__DIR__
   write(dir * "/intertypes.py", InterTypes.INTERTYPE_PYTHON_MODULE)
-  generate_python_module(simpleast, dir)
-  generate_python_module(model, dir)
-  generate_python_module(wgraph, dir)
+  generate_module(simpleast, :python, dir)
+  generate_module(model, :python, dir)
+  generate_module(wgraph, :python, dir)
 
   pushfirst!(PyList(pyimport("sys")."path"), Py(dir))
 


### PR DESCRIPTION
This refactors a few separate functions for module creation to be methods of the same functions. Now, instead of calling `generate_{export_type}_module(mod, ...)`, there is a single function `generate_module(mod, export_type)`